### PR TITLE
clarify use of staging::file target attribute

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -11,7 +11,7 @@
 #
 define staging::file (
   $source,              #: the source file location, supports local files, puppet://, http://, https://, ftp://
-  $target      = undef, #: the target staging directory, if unspecified ${staging::path}/${caller_module_name}
+  $target      = undef, #: the target file location, if unspecified ${staging::path}/${subdir}/${name}
   $username    = undef, #: https or ftp username
   $certificate = undef, #: https certificate file
   $password    = undef, #: https or ftp user password or https certificate password


### PR DESCRIPTION
The staging::file target attribute refers to the destination file path, but docs claimed it referred to the parent directory path. This simple comment update eliminates the confusion.