### PR TITLE
Add retries for the file transfer

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -19,6 +19,8 @@ define staging::file (
   $timeout     = undef, #: the the time to wait for the file transfer to complete
   $curl_option = undef, #: options to pass to curl
   $wget_option = undef, #: options to pass to wget
+  $tries       = undef, #: amount of retries for the file transfer when non transient connection errors exist
+  $try_sleep   = undef, #: time to wait between retries for the file transfer
   $subdir      = $caller_module_name
 ) {
 
@@ -46,6 +48,8 @@ define staging::file (
     cwd         => $staging_dir,
     creates     => $target_file,
     timeout     => $timeout,
+    try_sleep   => $try_sleep,
+    tries       => $tries,
     logoutput   => on_failure,
   }
 

--- a/spec/defines/staging_file_spec.rb
+++ b/spec/defines/staging_file_spec.rb
@@ -70,7 +70,9 @@ describe 'staging::file', :type => :define do
   describe 'when deploying via http with parameters' do
     let(:title) { 'sample.tar.gz' }
     let(:params) { { :source => 'http://webserver/sample.tar.gz',
-      :target => '/usr/local/sample.tar.gz',
+      :target    => '/usr/local/sample.tar.gz',
+      :tries     => '10',
+      :try_sleep => '6',
     } }
 
     it { should contain_file('/opt/staging')
@@ -80,6 +82,8 @@ describe 'staging::file', :type => :define do
         :environment => nil,
         :cwd         => '/usr/local',
         :creates     => '/usr/local/sample.tar.gz',
+        :tries       => '10',
+        :try_sleep   => '6',
       })
     }
   end


### PR DESCRIPTION
W/o this patch Staging::file cannot handle non transient (connectivity)
errors.
For example, curl or wget command could be used with their --retry keys,
but that would work only for transient (4xx/5xx) errors and would fail
when the connection was refused.

The solution is to add retries for the file transfer when non
transient connection errors exist

Closes-bug: #MODULES-1651

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>