### PR TITLE
Check for powershell first to avoid aliases for curl & wget

### DIFF
--- a/lib/facter/staging_http_get.rb
+++ b/lib/facter/staging_http_get.rb
@@ -17,7 +17,7 @@ Facter.add("staging_http_get") do
       result
     end
 
-    ['curl', 'wget', 'powershell'].each do |cmd|
+    ['powershell', 'curl', 'wget'].each do |cmd|
       available = which.call(cmd)
       fact = available ? cmd : nil
       break if fact


### PR DESCRIPTION
The latest version of powershell creates aliases for curl and wget, so the fact finds curl and tries to use it.  If we check for powershell first, it avoids those aliases.