### PR TITLE
Expose strip parameter to the staging::deploy defined type 

### DIFF
--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -7,6 +7,7 @@ define staging::deploy (
   $certificate  = undef, #: https certifcate file
   $password     = undef, #: https or ftp user password or https certificate password
   $environment  = undef, #: environment variable for settings such as http_proxy
+  $strip        = undef, #: extract file with the --strip=X option. Only works with GNU tar.
   $timeout      = undef, #: the time to wait for the file transfer to complete
   $user         = undef, #: extract file as this user
   $group        = undef, #: extract group as this group
@@ -32,6 +33,7 @@ define staging::deploy (
     user        => $user,
     group       => $group,
     environment => $environment,
+    strip       => $strip,
     subdir      => $caller_module_name,
     creates     => $creates,
     unless      => $unless,

--- a/spec/defines/staging_deploy_spec.rb
+++ b/spec/defines/staging_deploy_spec.rb
@@ -24,4 +24,22 @@ describe 'staging::deploy', :type => :define do
     }
   end
 
+  describe 'when deploying tar.gz with strip' do
+    let(:title) { 'sample.tar.gz' }
+    let(:params) { { :source => 'puppet:///modules/staging/sample.tar.gz',
+                     :target => '/usr/local' ,
+                     :strip  => 1, } }
+
+    it {
+      should contain_file('/opt/staging')
+      should contain_file('/opt/staging/spec/sample.tar.gz')
+      should contain_exec('extract sample.tar.gz').with({
+        :command => 'tar xzf /opt/staging/spec/sample.tar.gz --strip=1',
+        :path    => '/usr/local/bin:/usr/bin:/bin',
+        :cwd     => '/usr/local',
+        :creates => '/usr/local/sample'
+      })
+    }
+  end
+
 end


### PR DESCRIPTION
This is so that it can be used in the staging::extract defined type.

Issue: https://github.com/nanliu/puppet-staging/issues/62
