### PR TITLE
Added quotes around source and target for powershell downloads

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -71,7 +71,7 @@ define staging::file (
     'powershell':{
       $http_get           = "powershell.exe -Command \"\$wc = New-Object System.Net.WebClient;\$wc.DownloadFile('${source}','${target_file}')\""
       $ftp_get            = $http_get
-      $http_get_passwd  = "powershell.exe -Command \"\$wc = New-Object System.Net.WebClient;\$wc.Credentials = New-Object System.Net.NetworkCredential('${username}','${password}');\$wc.DownloadFile(${source},${target_file})\""
+      $http_get_passwd  = "powershell.exe -Command \"\$wc = New-Object System.Net.WebClient;\$wc.Credentials = New-Object System.Net.NetworkCredential('${username}','${password}');\$wc.DownloadFile('${source}','${target_file}')\""
       $ftp_get_passwd   = $http_get_passwd
     }
   }


### PR DESCRIPTION
Missed the quotes also, without the quotes, some url's will fail to download.