### PR TITLE
Correcting YAML syntax

### DIFF
--- a/spec/fixtures/hiera.yaml
+++ b/spec/fixtures/hiera.yaml
@@ -1,7 +1,9 @@
 ---
-:backends: - puppet
+:backends:
+    - puppet
 
-:hierarchy: - common
+:hierarchy:
+    - common
 
 :puppet:
     :datasource: data


### PR DESCRIPTION
One of our instructors noticed this in class because we've added a YAML syntax check to the pre-commit hook to our training VM:
https://github.com/puppetlabs/pltraining-classroom/blob/master/files/pre-commit#L24
