### PR TITLE
Pass full path as name

### DIFF
--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -16,7 +16,14 @@ define staging::deploy (
   $onlyif       = undef  #: alternative way to conditionally extract file
 ) {
 
-  staging::file { $name:
+  # grab file name if path was passed in
+  if $name =~ /.*\/(.*)/ {
+    $file_name = $1
+  } else {
+    $file_name = $name
+  }
+
+  staging::file { $file_name:
     source      => $source,
     target      => $staging_path,
     username    => $username,
@@ -27,7 +34,7 @@ define staging::deploy (
     timeout     => $timeout,
   }
 
-  staging::extract { $name:
+  staging::extract { $file_name:
     target      => $target,
     source      => $staging_path,
     user        => $user,
@@ -38,7 +45,7 @@ define staging::deploy (
     creates     => $creates,
     unless      => $unless,
     onlyif      => $onlyif,
-    require     => Staging::File[$name],
+    require     => Staging::File[$file_name],
   }
 
 }


### PR DESCRIPTION
I was using your module, and I noticed that if you pass in the full path to staging::deploy, it tries to use the full url as the name, which causes the file to be put in nested directories under the default stage.

When staging::extract is looking for the file, it looks where you would expect the file to be, but not where deploy puts it.  

I wasn't sure if I should send this pull request to you, or directly to the puppet-community version of the module.  Since yours is the one that is referenced by the puppet forge, I figured I'd ship it to you!

Thanks for considering my PR!
