### PR TITLE
Add support for OpenBSD

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -92,8 +92,8 @@ define staging::file (
         }
       } else {
         file { $target_file:
-          source             => $source,
-          replace            => false,
+          source  => $source,
+          replace => false,
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,5 +29,12 @@ class staging::params {
       $mode      = '0755'
       $exec_path = '/usr/local/bin:/usr/bin:/bin'
     }
+    'OpenBSD': {
+      $path      = '/var/staging'
+      $owner     = '0'
+      $group     = '0'
+      $mode      = '0755'
+      $exec_path = '/usr/local/bin:/usr/bin:/bin'
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -83,6 +83,13 @@
         "6.1",
         "7.1"
       ]
+    },
+    {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "5.7",
+        "5.8"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Hi,

even that the README states, 1.0.0 is the last version of the module, and it's already at 1.0.4, I hope you don't mind adding support for OpenBSD. I'ts just lightly tested, the rabbitmq module I use uses the staging module.

Added a case statement for OpenBSD to the params.pp, and to the metadata.json.

Further updated one file, to please travis-ci, puppet-lint ;)

let me know if there is something wrong, and I could do some more to get it merged.

thanks,
Sebastian
